### PR TITLE
Crop production improvement

### DIFF
--- a/include/daisy/crop/production.h
+++ b/include/daisy/crop/production.h
@@ -46,8 +46,10 @@ class Production
   // Remobilization.
 private:
   const double ShldResC;	// Capacity of Shielded Reserves
+  const double ReMobilEff;      // Remobilization efficiency
   const double ReMobilDS;	// Remobilization, Initial DS
   const double ReMobilRt;	// Remobilization, release rate
+  const PLF& ReMobil_Mod;	// Remobilization, release rate modifier
   double StemRes;		// Shielded Reserves in Stems
   double remobilization (const double DS, const double dt);
 

--- a/include/daisy/crop/production.h
+++ b/include/daisy/crop/production.h
@@ -60,6 +60,7 @@ public:
   const double E_Stem;		// Conversion efficiency, stem
   const double E_SOrg;		// Conversion efficiency, stor. org.
 private:
+  const PLF& MaintResp_DS;      // Maint. resp. reduction due to senescence
   const double r_Root;		// Maint. resp. coeff., root
   const double r_Leaf;		// Maint. resp. coeff., leaf
   const double r_Stem;		// Maint. resp. coeff., stem

--- a/src/daisy/crop/production.C
+++ b/src/daisy/crop/production.C
@@ -191,16 +191,16 @@ Production::tick (const double AirT, const double SoilT,
 
   // Maintenance respiration.
   double RMLeaf                 // [g CH2O/m^2/h]
-    = maintenance_respiration (r_Leaf, WLeaf, AirT);
+    = maintenance_respiration (r_Leaf, WLeaf, AirT) * MaintResp_DS(DS);
   daisy_assert (std::isfinite (RMLeaf));
   const double RMStem           // [g CH2O/m^2/h]
-    = maintenance_respiration (r_Stem, WStem, AirT);
+    = maintenance_respiration (r_Stem, WStem, AirT) * MaintResp_DS(DS);
   daisy_assert (std::isfinite (RMStem));
   const double RMSOrg           // [g CH2O/m^2/h]
-    = maintenance_respiration (r_SOrg, WSOrg, AirT);
+    = maintenance_respiration (r_SOrg, WSOrg, AirT) * MaintResp_DS(DS);
   daisy_assert (std::isfinite (RMSOrg));
   const double RMRoot           // [g CH2O/m^2/h]
-    = maintenance_respiration (r_Root, WRoot, SoilT);
+    = maintenance_respiration (r_Root, WRoot, SoilT) * MaintResp_DS(DS);
   daisy_assert (std::isfinite (RMRoot));
 
   // Water stress stops leaf respiration.
@@ -727,6 +727,9 @@ Production::load_syntax (Frame& frame)
   frame.set ("E_Stem", 0.66);
   frame.declare ("E_SOrg", "g DM-C/g Ass-C", Attribute::Const,
 	      "Conversion efficiency, storage organ.");
+  frame.declare ("MaintResp_DS", "DS", Attribute::None (), Attribute::Const,
+          "Reduction of maintenance respiration with crop senescence");
+  frame.set ("MaintResp_DS", PLF::always_1 ());
   frame.declare ("r_Root", "d^-1", Attribute::Const,
 	      "Maintenance respiration coefficient, root.");
   frame.set ("r_Root", 0.015);
@@ -946,6 +949,7 @@ Production::Production (const FrameSubmodel& al)
     E_Leaf (al.number ("E_Leaf")),
     E_Stem (al.number ("E_Stem")),
     E_SOrg (al.number ("E_SOrg")),
+    MaintResp_DS (al.plf ("MaintResp_DS")),
     r_Root (al.number ("r_Root")),
     r_Leaf (al.number ("r_Leaf")),
     r_Stem (al.number ("r_Stem")),

--- a/src/daisy/crop/production.C
+++ b/src/daisy/crop/production.C
@@ -66,7 +66,7 @@ Production::remobilization (const double DS, const double dt)
     }
   else
     {
-      const double ReMobilization = ReMobilRt / 24. * StemRes;
+      const double ReMobilization = ReMobilRt / 24. * ReMobil_Mod (DS) * StemRes;
       StemRes -= ReMobilization * dt;
       return ReMobilization;
     }
@@ -165,7 +165,7 @@ Production::tick (const double AirT, const double SoilT,
   const double ReMobil = remobilization (DS, dt); // [g DM/m^2/h]
   const double CH2OReMobil                        // [g CH2O/m^2/h]
     = ReMobil * DM_to_C_factor (E_Stem) * 30.0/12.0;
-  const double ReMobilResp = CH2OReMobil - ReMobil; // [g CH2O/m^2/h]
+  const double ReMobilResp = (1 - ReMobilEff) * CH2OReMobil; // [g CH2O/m^2/h]
   // Note:  We used to have "CH2OPool += Remobil", but that does not
   // give C balance.  ReMobilResp was invented, and gets it's strange
   // value, to get the same result but with a mass balance.  
@@ -702,12 +702,18 @@ Production::load_syntax (Frame& frame)
   frame.declare ("ShldResC", Attribute::Fraction (), Attribute::Const,
 	      "Capacity of shielded reserves (fraction of stem DM).");
   frame.set ("ShldResC", 0.0);
+  frame.declare ("ReMobilEff", Attribute::Fraction (), Attribute::Const,
+          "Efficiency of reserve mobilization");
+  frame.set ("ReMobilEff", 0.85);
   frame.declare ("ReMobilDS", "DS", Attribute::Const,
 	      "Remobilization, Initial DS.");
   frame.set ("ReMobilDS", 1.20);
   frame.declare ("ReMobilRt", "d^-1", Attribute::Const,
 	      "Remobilization, release rate.");
   frame.set ("ReMobilRt", 0.1);
+  frame.declare ("ReMobil_Mod", "DS", Attribute::None (), Attribute::Const,
+        "Modifier of remobilization rate depending on DS.");
+  frame.set ("ReMobil_Mod", PLF::always_1 ());
   frame.declare ("StemRes", "g DM/m^2", Attribute::State,
 	      "Shielded reserves in stems.");
   frame.set ("StemRes", 0.0);
@@ -940,8 +946,10 @@ Production::initialize (const Metalib& metalib, const symbol name,
 
 Production::Production (const FrameSubmodel& al)
   : ShldResC (al.number ("ShldResC")),
+    ReMobilEff (al.number ("ReMobilEff")),
     ReMobilDS (al.number ("ReMobilDS")),
     ReMobilRt (al.number ("ReMobilRt")),
+    ReMobil_Mod (al.plf ("ReMobil_Mod")),
     StemRes (al.number ("StemRes")),
     // Parameters.
     CH2OReleaseRate (al.number ("CH2OReleaseRate")),


### PR DESCRIPTION
Remobilisation rate can be modified as a function of DS, as the evolution of stem reserves remobilisation follows a sigmoid curve rather than a constant rate (Ehdaie et al., 2008 - doi:10.1016/j.fcr.2007.10.012). The efficiency of this remobilisation can now be parameterised (resolving a prolem in the previous equation in terms of units).

Maintenance respiration is not expected to be constant during all the crop development (Amthor, 2025 - doi:10.1016/j.fcr.2024.109638), it can now be modified (but constant by default). Note that, in our study, NEE measurements also show that maintenance respiration is overestimated by Daisy when winter wheat crop is in the late reproductive stage.