### PR TITLE
Fix boost dylibs relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ Build a portable binary
     cmake ../../ --preset macos-clang-portable
     cmake --build . -j <number-of-concurrent-jobs>
 
+Check that dynamic library paths have been updated to relative paths
+
+	otool -L ./daisy
+
+Should yield something similar to
+
+	./daisy:
+	@rpath/lib/libcxsparse.4.dylib (compatibility version 4.0.0, current version 4.4.1)
+	@rpath/lib/libboost_filesystem.dylib (compatibility version 0.0.0, current version 0.0.0)
+	@rpath/lib/libboost_atomic.dylib (compatibility version 0.0.0, current version 0.0.0)
+	@rpath/lib/libboost_system.dylib (compatibility version 0.0.0, current version 0.0.0)
+	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1900.180.0)
+	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
+
+If cxsparse or boost libs have paths that do not start with @rpath, then you need to update cmake/MacOS.cmake and rerun both cmake steps.
+
+
 Make an installer
 
     cpack

--- a/cmake/MacOS.cmake
+++ b/cmake/MacOS.cmake
@@ -60,12 +60,12 @@ set_target_properties(daisy
 
 # Then update the id of dylibs
 # This is brittle. Would be nice to get the dir path dynamically.
-set(_boost_id_prefix "boost@1.85/")
+set(_boost_id_prefix "boost/")
 set(_dylibs_rel_path
   "suite-sparse/lib/libcxsparse.4.dylib"
-  "${_boost_id_prefix}lib/libboost_filesystem-mt.dylib"
-  "${_boost_id_prefix}lib/libboost_system-mt.dylib"
-  "${_boost_id_prefix}lib/libboost_atomic-mt.dylib"
+  "${_boost_id_prefix}lib/libboost_filesystem.dylib"
+  "${_boost_id_prefix}lib/libboost_system.dylib"
+  "${_boost_id_prefix}lib/libboost_atomic.dylib"
   "${_boost_id_prefix}lib/libboost_process.dylib"
 )
 foreach(_dylib_rel_path ${_dylibs_rel_path})


### PR DESCRIPTION
Boost dylibs on MacOS are a moving target. So I have fixed them for now and added a note in the README under MacOS build that you need to check they are updated correctly.