### PR TITLE
Add tagged release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to validate against CMakeLists.txt, for example v7.1.12
+        required: true
+        type: string
+      publish:
+        description: Publish a GitHub release after building artifacts
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -19,6 +30,7 @@ jobs:
     outputs:
       should_release: ${{ steps.validate.outputs.should_release }}
       release_tag: ${{ steps.validate.outputs.release_tag }}
+      publish_release: ${{ steps.validate.outputs.publish_release }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -26,10 +38,14 @@ jobs:
 
       - id: validate
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
           RELEASE_SHA: ${{ github.sha }}
+          REQUEST_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && inputs.publish || 'false' }}
         run: |
           echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "publish_release=false" >> "$GITHUB_OUTPUT"
 
           if ! printf '%s\n' "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Skipping: $RELEASE_TAG is not a stable release tag."
@@ -43,11 +59,20 @@ jobs:
             exit 1
           fi
 
-          git fetch --no-tags origin main
-          main_sha="$( git rev-parse origin/main )"
-          if [ "$RELEASE_SHA" != "$main_sha" ]; then
-            echo "Error: tag must point at the current origin/main HEAD ($main_sha)."
-            exit 1
+          if [ "$EVENT_NAME" = "push" ] || [ "$REQUEST_PUBLISH" = "true" ]; then
+            git fetch --no-tags origin main
+            main_sha="$( git rev-parse origin/main )"
+            if [ "$REF_NAME" != "main" ] && [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "Error: manual publish must run from the main branch."
+              exit 1
+            fi
+            if [ "$RELEASE_SHA" != "$main_sha" ]; then
+              echo "Error: release must point at the current origin/main HEAD ($main_sha)."
+              exit 1
+            fi
+            echo "publish_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Manual dry run: building artifacts without publishing a GitHub release."
           fi
 
           echo "should_release=true" >> "$GITHUB_OUTPUT"
@@ -152,7 +177,7 @@ jobs:
       - build-linux
       - build-macos
       - build-windows
-    if: needs.preflight.outputs.should_release == 'true'
+    if: needs.preflight.outputs.should_release == 'true' && needs.preflight.outputs.publish_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: Build packages and publish release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.validate.outputs.should_release }}
+      release_tag: ${{ steps.validate.outputs.release_tag }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - id: validate
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+
+          if ! printf '%s\n' "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Skipping: $RELEASE_TAG is not a stable release tag."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cmake_version="$( sed -n '/project(/,/)/ s/.*VERSION \([0-9.]*\).*/\1/p' CMakeLists.txt | head -n1 )"
+          if [ "v${cmake_version}" != "$RELEASE_TAG" ]; then
+            echo "Error: tag $RELEASE_TAG does not match project version v${cmake_version}."
+            exit 1
+          fi
+
+          git fetch --no-tags origin main
+          main_sha="$( git rev-parse origin/main )"
+          if [ "$RELEASE_SHA" != "$main_sha" ]; then
+            echo "Error: tag must point at the current origin/main HEAD ($main_sha)."
+            exit 1
+          fi
+
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+  build-linux:
+    name: Build Linux package
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake flatpak flatpak-builder libsuitesparse-dev libboost-filesystem-dev python3-pybind11
+
+      - name: Configure Flathub
+        run: flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build Linux packages
+        run: make linux
+
+      - name: Upload Linux packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-linux
+          path: |
+            build/linux-gcc-portable/*.deb
+            flatpak/*.flatpak
+          if-no-files-found: error
+
+  build-macos:
+    name: Build macOS package
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install build dependencies
+        run: brew install cmake boost suite-sparse pybind11
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.18"
+
+      - name: Build macOS package
+        run: make macos
+
+      - name: Upload macOS packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos
+          path: build/macos-clang-portable/*.zip
+          if-no-files-found: error
+
+  build-windows:
+    name: Build Windows packages
+    needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            git
+            make
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-suitesparse
+            mingw-w64-ucrt-x86_64-boost
+            mingw-w64-ucrt-x86_64-pybind11
+            mingw-w64-ucrt-x86_64-uv
+            nsis
+
+      - uses: actions/checkout@v5
+
+      - name: Build Windows packages
+        run: make windows
+
+      - name: Upload Windows packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows
+          path: |
+            build/mingw-gcc-portable/*.exe
+            build/mingw-gcc-portable/*.zip
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish GitHub release
+    needs:
+      - preflight
+      - build-linux
+      - build-macos
+      - build-windows
+    if: needs.preflight.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist
+
+      - name: Create or update GitHub release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || gh release create "$RELEASE_TAG" --generate-notes
+          gh release upload "$RELEASE_TAG" dist/* --clobber

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,35 @@
 daisy_version := $(shell scripts/get_version_from_cmake.sh)
+daisy_tag := v$(daisy_version)
 current_dir := $(shell pwd)
 has_gcovr := $(shell command -v gcovr 2> /dev/null)
 python_version = 3.13
-python_root := $(shell scripts/find_python_root_dir.sh ${PYTHON_VERSION})
+python_root = $(shell scripts/find_python_root_dir.sh ${python_version})
 nproc := 6
 
 # Python
 .PHONY: uv-python
 uv-python:
 	uv python install $(python_version)
+
+
+# Release
+.PHONY: release-tag
+release-tag:
+	@git fetch --no-tags origin main
+	@if [ "$$( git rev-parse --abbrev-ref HEAD )" != "main" ]; then \
+		echo "Refusing to tag: current branch is not main"; \
+		exit 1; \
+	fi
+	@if [ "$$( git rev-parse HEAD )" != "$$( git rev-parse origin/main )" ]; then \
+		echo "Refusing to tag: local main is not at origin/main HEAD"; \
+		exit 1; \
+	fi
+	@if git rev-parse "$(daisy_tag)" >/dev/null 2>&1; then \
+		echo "Refusing to tag: $(daisy_tag) already exists"; \
+		exit 1; \
+	fi
+	git tag -a "$(daisy_tag)" -m "Release $(daisy_tag)"
+	@echo "Created tag $(daisy_tag)"
 
 
 # Windows

--- a/doc/build-daisy.md
+++ b/doc/build-daisy.md
@@ -22,5 +22,6 @@ to the cmake configure command, e.g.
 * [Linux](build-instructions-linux.md)
 * [MacOS](build-instructions-macos.md)
 * [Windows](build-instructions-windows.md)
+* [Making a release](making-a-release.md)
 
 Documentation: [build-documentation.md](build-documentation.md)

--- a/doc/making-a-release.md
+++ b/doc/making-a-release.md
@@ -8,6 +8,17 @@ Releases are created from tags on `main`. The release workflow will only publish
 
 If any of these checks fail, the workflow fails and no release is published.
 
+## Test the release workflow
+
+The workflow can be started manually from the GitHub Actions page with `workflow_dispatch`. This is useful for testing the package builds without publishing a real release.
+
+Choose the `Build packages and publish release` workflow, select a branch, and provide:
+
+* `release_tag`: a stable version tag such as `v7.1.12`
+* `publish`: leave this as `false` for a dry run
+
+With `publish=false`, the workflow validates the version, builds the Linux, MacOS, and Windows packages, and uploads them as workflow artifacts, but it does not create a GitHub release.
+
 ## 1. Update the version
 
 Set the release version in `CMakeLists.txt`

--- a/doc/making-a-release.md
+++ b/doc/making-a-release.md
@@ -1,0 +1,52 @@
+# Making a release
+
+Releases are created from tags on `main`. The release workflow will only publish a release when all of the following are true:
+
+* the tag has the form `vX.Y.Z`
+* the version in `CMakeLists.txt` matches the tag
+* the tagged commit is the current `main` HEAD
+
+If any of these checks fail, the workflow fails and no release is published.
+
+## 1. Update the version
+
+Set the release version in `CMakeLists.txt`
+
+```cmake
+project(
+  daisy
+  VERSION X.Y.Z
+  ...
+)
+```
+
+Commit that change on a branch, open a pull request, and merge it to `main`.
+
+## 2. Create the release tag
+
+Update your local `main` to the merged `origin/main` HEAD
+
+    git checkout main
+    git pull --ff-only origin main
+
+Then create the tag from the version in `CMakeLists.txt`
+
+    make release-tag
+
+This creates an annotated tag named `vX.Y.Z`. The target refuses to tag unless your local `main` is exactly at the current `origin/main` HEAD.
+
+## 3. Push the tag
+
+Push the new tag to GitHub
+
+    git push origin vX.Y.Z
+
+## 4. Wait for the release workflow
+
+Pushing the tag starts the GitHub release workflow. It will build and publish these release artifacts:
+
+* Linux: `.deb` and `.flatpak`
+* MacOS: `.zip`
+* Windows: `.exe` installer and `.zip`
+
+The workflow then creates or updates the GitHub release for that tag and uploads the artifacts.


### PR DESCRIPTION
## Summary
- add a tag-driven GitHub release workflow for Linux, macOS, and Windows artifacts
- enforce version/tag and main-head checks, plus add a Makefile release-tag helper
- document the protected-branch release process and link it from build docs