### PR TITLE
Fix macOS packaging by recursively bundling runtime dylibs

### DIFF
--- a/cmake/FixupMacOSDependencies.cmake
+++ b/cmake/FixupMacOSDependencies.cmake
@@ -1,0 +1,126 @@
+cmake_minimum_required(VERSION 3.25)
+
+foreach(_required_var DAISY_EXECUTABLE DAISY_STAGING_DIR DAISY_DYLIB_TARGET_DIR HOMEBREW_PREFIX)
+  if(NOT DEFINED ${_required_var} OR "${${_required_var}}" STREQUAL "")
+    message(FATAL_ERROR "Missing required variable ${_required_var}")
+  endif()
+endforeach()
+
+function(_daisy_run_install_name_tool)
+  execute_process(
+    COMMAND install_name_tool ${ARGN}
+    RESULT_VARIABLE _result
+    ERROR_VARIABLE _error
+  )
+  if(NOT _result EQUAL 0)
+    string(JOIN " " _command ${ARGN})
+    message(FATAL_ERROR "install_name_tool ${_command} failed: ${_error}")
+  endif()
+endfunction()
+
+function(_daisy_fixup_load_commands target mode)
+  execute_process(
+    COMMAND otool -L "${target}"
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _output
+    ERROR_VARIABLE _error
+  )
+  if(NOT _result EQUAL 0)
+    message(FATAL_ERROR "otool -L ${target} failed: ${_error}")
+  endif()
+
+  string(REPLACE "\n" ";" _lines "${_output}")
+  list(REMOVE_AT _lines 0)
+  foreach(_line IN LISTS _lines)
+    string(STRIP "${_line}" _line)
+    if(_line STREQUAL "")
+      continue()
+    endif()
+    string(REGEX REPLACE "^([^ ]+) .*" "\\1" _old_name "${_line}")
+    cmake_path(GET _old_name FILENAME _dep_name)
+
+    set(_new_name "")
+    if(_dep_name IN_LIST _daisy_staged_lib_names)
+      if(mode STREQUAL "EXECUTABLE")
+        set(_new_name "@rpath/lib/${_dep_name}")
+      else()
+        set(_new_name "@loader_path/${_dep_name}")
+      endif()
+    elseif(DEFINED DAISY_PYTHON_DYLIB_NAME AND NOT "${DAISY_PYTHON_DYLIB_NAME}" STREQUAL "" AND _dep_name STREQUAL "${DAISY_PYTHON_DYLIB_NAME}")
+      if(mode STREQUAL "EXECUTABLE")
+        set(_new_name "@executable_path/../python/lib/${_dep_name}")
+      else()
+        set(_new_name "@loader_path/../python/lib/${_dep_name}")
+      endif()
+    endif()
+
+    if(NOT _new_name STREQUAL "" AND NOT _old_name STREQUAL _new_name)
+      _daisy_run_install_name_tool(-change "${_old_name}" "${_new_name}" "${target}")
+    endif()
+  endforeach()
+endfunction()
+
+set(_search_dirs
+  "${HOMEBREW_PREFIX}/lib"
+  "${HOMEBREW_PREFIX}/opt/libomp/lib"
+  "${DAISY_DYLIB_TARGET_DIR}"
+)
+if(DEFINED DAISY_PYTHON_ROOT_DIR AND NOT "${DAISY_PYTHON_ROOT_DIR}" STREQUAL "")
+  list(APPEND _search_dirs "${DAISY_PYTHON_ROOT_DIR}/lib")
+endif()
+list(REMOVE_DUPLICATES _search_dirs)
+
+set(_tmp_dylib_dir "${DAISY_DYLIB_TARGET_DIR}.tmp")
+file(REMOVE_RECURSE "${_tmp_dylib_dir}")
+file(MAKE_DIRECTORY "${_tmp_dylib_dir}")
+
+file(GET_RUNTIME_DEPENDENCIES
+  RESOLVED_DEPENDENCIES_VAR _resolved_deps
+  UNRESOLVED_DEPENDENCIES_VAR _unresolved_deps
+  EXECUTABLES "${DAISY_EXECUTABLE}"
+  DIRECTORIES ${_search_dirs}
+  POST_EXCLUDE_REGEXES
+    "^/System/Library/"
+    "^/usr/lib/"
+)
+
+if(_unresolved_deps)
+  list(JOIN _unresolved_deps "\n  " _joined_unresolved)
+  message(FATAL_ERROR "Unresolved macOS runtime dependencies:\n  ${_joined_unresolved}")
+endif()
+
+set(_deps_to_stage "")
+foreach(_dep IN LISTS _resolved_deps)
+  if(DEFINED DAISY_PYTHON_ROOT_DIR AND NOT "${DAISY_PYTHON_ROOT_DIR}" STREQUAL "")
+    string(FIND "${_dep}" "${DAISY_PYTHON_ROOT_DIR}/" _python_root_prefix_index)
+    if(_python_root_prefix_index EQUAL 0)
+      continue()
+    endif()
+  endif()
+  list(APPEND _deps_to_stage "${_dep}")
+endforeach()
+list(REMOVE_DUPLICATES _deps_to_stage)
+
+if(_deps_to_stage)
+  file(COPY ${_deps_to_stage}
+    DESTINATION "${_tmp_dylib_dir}"
+    FOLLOW_SYMLINK_CHAIN
+  )
+endif()
+
+set(_daisy_staged_lib_names "")
+file(GLOB _staged_libs RELATIVE "${_tmp_dylib_dir}" "${_tmp_dylib_dir}/*.dylib")
+foreach(_staged_lib IN LISTS _staged_libs)
+  list(APPEND _daisy_staged_lib_names "${_staged_lib}")
+endforeach()
+
+foreach(_staged_lib_name IN LISTS _daisy_staged_lib_names)
+  set(_staged_lib_path "${_tmp_dylib_dir}/${_staged_lib_name}")
+  _daisy_run_install_name_tool(-id "@rpath/lib/${_staged_lib_name}" "${_staged_lib_path}")
+  _daisy_fixup_load_commands("${_staged_lib_path}" "DYLIB")
+endforeach()
+
+_daisy_fixup_load_commands("${DAISY_EXECUTABLE}" "EXECUTABLE")
+
+file(REMOVE_RECURSE "${DAISY_DYLIB_TARGET_DIR}")
+file(RENAME "${_tmp_dylib_dir}" "${DAISY_DYLIB_TARGET_DIR}")

--- a/cmake/MacOS.cmake
+++ b/cmake/MacOS.cmake
@@ -18,79 +18,22 @@ install(TARGETS ${DAISY_BIN_NAME}
   COMPONENT runtime
 )
 
-# When making an installer we want to be able to redistribute the dylibs and find them.
-#
-# Copy dylibs so we can redistribute. First copy to a directory in the build tree. CMake will
-# handle symlinks. Then install all the files we just copied.
-# We put them in bin/lib, then we dont need to update the rpath of the shared library files
-# because they look in @loader_path/../lib, which becomes lib/
+# Stage non-target runtime files that will be installed alongside the packaged
+# executable. Runtime library fixups are handled by a post-build CMake script.
 set(_staging_dir "${CMAKE_CURRENT_BINARY_DIR}/_staging")
-set(_boost_path_prefix "")
 set(_dylib_target_dir "${_staging_dir}/bin/lib")
-file(INSTALL
-  "${HOMEBREW_PREFIX}/lib/libcxsparse.4.dylib"
-  "${HOMEBREW_PREFIX}/lib/libsuitesparseconfig.7.dylib"
-  "${HOMEBREW_PREFIX}/${_boost_path_prefix}lib/libboost_filesystem.dylib"
-  "${HOMEBREW_PREFIX}/${_boost_path_prefix}lib/libboost_container.dylib"
-  "${HOMEBREW_PREFIX}/${_boost_path_prefix}lib/libboost_atomic.dylib"
-  "${HOMEBREW_PREFIX}/${_boost_path_prefix}lib/libboost_process.dylib"
-  "${HOMEBREW_PREFIX}/${_boost_path_prefix}lib/libboost_context.dylib"
-  "${HOMEBREW_PREFIX}/${_boost_path_prefix}lib/libboost_date_time.dylib"
-  "${HOMEBREW_PREFIX}/opt/libomp/lib/libomp.dylib"
-  DESTINATION ${_dylib_target_dir}
-  FOLLOW_SYMLINK_CHAIN
-)
 
-# Update daisy binary so it knows to look in @executable_path for dylibs
-# First update the rpath.
-# For the installed binary we use @executable_path directly because it is installed to
-#  <prefix/bin
-# which contain lib/ with shared libraries.
-# For the build binary we use @executable_path/bin because the binary is not moved to the bin dir
+# The packaged executable lives in Daisy/bin and its bundled libraries live in
+# Daisy/bin/lib. In the build tree, the post-build fixup script stages those
+# libraries under _staging/bin/lib relative to daisy-bin.
 set_target_properties(${DAISY_BIN_NAME}
   PROPERTIES
   INSTALL_RPATH "@executable_path"
-  BUILD_RPATH "@executable_path/bin"
+  BUILD_RPATH "@executable_path/_staging/bin"
 )
 
-# Then update the id of dylibs
-# This is brittle. Would be nice to get the dir path dynamically.
-set(_boost_id_prefix "boost/")
-set(_dylibs_rel_path
-  "suite-sparse/lib/libcxsparse.4.dylib"
-  "${_boost_id_prefix}lib/libboost_filesystem.dylib"
-  "${_boost_id_prefix}lib/libboost_container.dylib"
-  "${_boost_id_prefix}lib/libboost_atomic.dylib"
-  "${_boost_id_prefix}lib/libboost_process.dylib"
-  "${_boost_id_prefix}lib/libboost_context.dylib"
-  "${_boost_id_prefix}lib/libboost_date_time.dylib"
-)
-foreach(_dylib_rel_path ${_dylibs_rel_path})
-  set(_old_lib_id "${HOMEBREW_PREFIX}/opt/${_dylib_rel_path}")
-  cmake_path(GET _old_lib_id FILENAME _dylib)
-  set(_new_lib_id "@rpath/lib/${_dylib}")
-
-  message("-- In ${DAISY_BIN_NAME}: Change ${_old_lib_id} -> ${_new_lib_id}")
-  add_custom_command(TARGET ${DAISY_BIN_NAME}
-    POST_BUILD
-    COMMAND "install_name_tool"
-    ARGS "-change" "${_old_lib_id}" "${_new_lib_id}"
-    "${DAISY_BIN_NAME}"
-  )
-endforeach()
-
-# We also need to update the path of libomp in libsuitesparseconfig
-set(_old_lib_id "${HOMEBREW_PREFIX}/opt/libomp/lib/libomp.dylib")
-set(_new_lib_id "@rpath/libomp.dylib")
-set(_suitesparseconfig "${_dylib_target_dir}/libsuitesparseconfig.7.dylib")
-message("-- In ${_suitesparseconfig}: Change ${_old_lib_id} -> ${_new_lib_id}")
-add_custom_command(TARGET ${DAISY_BIN_NAME}
-  POST_BUILD
-  COMMAND "install_name_tool"
-  ARGS "-change" "${_old_lib_id}" "${_new_lib_id}"
-  "${_suitesparseconfig}"
-)
-
+set(_python_dir "")
+set(_python_dylib_name "")
 if (${BUILD_PYTHON})
   # We add python version to distribution name, so people can see the version they get
   set(DAISY_PYTHON_VERSION "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
@@ -107,25 +50,12 @@ if (${BUILD_PYTHON})
     PATTERN "include" EXCLUDE             # We dont need header files
   )
 
-  # Replace the id of the python dylib to avoid leaking info about build
-  # Not necesary for running, because we will never link new objects against
-  # the dylib.
+  # Replace the id of the python dylib to avoid leaking info about build.
   set(_python_dylib_relpath "${_staging_dir}/python/lib/${_python_dylib_name}")
-  message("-- In ${_python_dylib_relpath}: Change id to ${_python_dylib_name}")
   add_custom_command(TARGET ${DAISY_BIN_NAME}
     POST_BUILD
     COMMAND "install_name_tool"
     ARGS "-id" "${_python_dylib_name}" "${_python_dylib_relpath}"
-  )
-
-  # Update the python dylib path in daisy binary
-  set(_new_lib_id "@executable_path/../python/lib/${_python_dylib_name}")
-  message("-- In ${DAISY_BIN_NAME}: Change ${_old_lib_id} -> ${_new_lib_id}")
-  add_custom_command(TARGET ${DAISY_BIN_NAME}
-    POST_BUILD
-    COMMAND "install_name_tool"
-    ARGS "-change" "${_old_lib_id}" "${_new_lib_id}"
-    "${DAISY_BIN_NAME}"
   )
 
   # Install the wrapper script that calls daisy with python
@@ -145,6 +75,18 @@ else()
   )
 endif()
 
+add_custom_command(TARGET ${DAISY_BIN_NAME}
+  POST_BUILD
+  COMMAND "${CMAKE_COMMAND}"
+  ARGS
+    -DDAISY_EXECUTABLE=$<TARGET_FILE:${DAISY_BIN_NAME}>
+    -DDAISY_STAGING_DIR=${_staging_dir}
+    -DDAISY_DYLIB_TARGET_DIR=${_dylib_target_dir}
+    -DDAISY_PYTHON_ROOT_DIR=${_python_dir}
+    -DDAISY_PYTHON_DYLIB_NAME=${_python_dylib_name}
+    -DHOMEBREW_PREFIX=${HOMEBREW_PREFIX}
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FixupMacOSDependencies.cmake
+)
 
 # Install the staged stuff
 install(DIRECTORY ${_staging_dir}/


### PR DESCRIPTION
The previous macOS packaging logic copied a hardcoded list of Homebrew dylibs and rewrote only selected install names, which broke when Boost gained new transitive dependencies and left build-tree rpaths fragile. Replace that with a post-build CMake fixup step that discovers non-system runtime dependencies recursively, stages them into the package, and rewrites executable and dylib load commands to the packaged layout.